### PR TITLE
Restyle V3 testing UI with purple vortex theme

### DIFF
--- a/V3-testing.ps1
+++ b/V3-testing.ps1
@@ -246,34 +246,34 @@ function Set-BorderBrushSafe {
 # ---------- COMPLETE THEME ARRAY - ALL COLORS CENTRALIZED! ----------
 $global:ThemeDefinitions = @{
     'Nebula' = @{
-        Name = 'Nebula Night'
-        Background = '#090B1A'
-        Primary = '#5D5FEF'
-        Hover = '#7E7FFF'
-        Text = '#F5F6FF'
-        Secondary = '#10142A'
-        Accent = '#9D7BFF'
-        TextSecondary = '#A4AFDF'
-        LogBg = '#0F1428'
-        SidebarBg = '#0E1429'
-        HeaderBg = '#121B39'
-        Success = '#10B981'
-        Warning = '#F59E0B'
-        Danger = '#EF4444'
-        Info = '#8B5CF6'
-        CardBackgroundStart = '#1A1F3F'
-        CardBackgroundEnd = '#10142A'
-        SummaryBackgroundStart = '#272F62'
-        SummaryBackgroundEnd = '#151B3A'
-        CardBorder = '#5D5FEF'
-        GlowAccent = '#B59BFF'
-        GaugeBackground = '#151D3B'
-        GaugeStroke = '#9D7BFF'
-        SelectedBackground = '#5D5FEF'
+        Name = 'Nebula Vortex'
+        Background = '#080716'
+        Primary = '#8F6FFF'
+        Hover = '#A78BFA'
+        Text = '#F5F3FF'
+        Secondary = '#14132B'
+        Accent = '#B497FF'
+        TextSecondary = '#A9A5D9'
+        LogBg = '#0B0A1D'
+        SidebarBg = '#0E0C21'
+        HeaderBg = '#151233'
+        Success = '#34D399'
+        Warning = '#FBBF24'
+        Danger = '#F87171'
+        Info = '#60A5FA'
+        CardBackgroundStart = '#19173A'
+        CardBackgroundEnd = '#0F0D22'
+        SummaryBackgroundStart = '#241F4D'
+        SummaryBackgroundEnd = '#131029'
+        CardBorder = '#2F285A'
+        GlowAccent = '#8F6FFF'
+        GaugeBackground = '#100F25'
+        GaugeStroke = '#B197FF'
+        SelectedBackground = '#8F6FFF'
         UnselectedBackground = 'Transparent'
-        SelectedForeground = '#0B0F1E'
-        UnselectedForeground = '#D5DAFF'
-        HoverBackground = '#242B53'
+        SelectedForeground = '#F5F3FF'
+        UnselectedForeground = '#A9A5D9'
+        HoverBackground = '#1F1B3F'
         IsLight = $false
     }
     'Midnight' = @{
@@ -451,8 +451,8 @@ function Ensure-NavigationVisibility {
 
                     # Ensure proper styling
                     if (-not $button.Style) {
-                        $button.Background = '#2F3A73'
-                        $button.Foreground = 'White'
+                        $button.Background = '#2F285A'
+                        $button.Foreground = '#F5F3FF'
                         $button.BorderThickness = '0'
                         $button.Margin = '0,2'
                         $button.Padding = '15,10'
@@ -1272,7 +1272,7 @@ function Update-AllUIElementsRecursively {
             "Border" {
                 $currentBg = if ($element.Background) { $element.Background.ToString() } else { $null }
 
-                if ($currentBg -match "#161D3F|#1B2345|#141830|#1A1F39|#141830|#F8F9FA|#FFFFFF|#F0F2F5") {
+                if ($currentBg -match "#161D3F|#1B2345|#141830|#1A1F39|#141830|#14132B|#F8F9FA|#FFFFFF|#F0F2F5") {
                     $element.Background = $colors.Secondary
                 }
                 if ($currentBg -match "#0E101A|#36393F|#0E0E10") {
@@ -1345,10 +1345,10 @@ function Update-AllUIElementsRecursively {
             "TextBlock" {
                 $currentForeground = if ($element.Foreground) { $element.Foreground.ToString() } else { $null }
 
-                if ($currentForeground -match "#5D5FEF|#5D5FEF|#8A77FF") {
+                if ($currentForeground -match "#8F6FFF|#B497FF|#5D5FEF|#8A77FF") {
                     $element.Foreground = $colors.Accent
                 }
-                elseif ($currentForeground -match "#A6AACF|#B8B8B8|#777EA6888|#6C757D|#8B949E") {
+                elseif ($currentForeground -match "#A9A5D9|#A6AACF|#B8B8B8|#777EA6888|#6C757D|#8B949E") {
                     $element.Foreground = $colors.TextSecondary
                 }
                 elseif ($currentForeground -match "White|#FFFFFF|Black|#000000|#212529|#1C1E21") {
@@ -1908,26 +1908,28 @@ function Apply-ThemeColors {
             $innerGaugeBrush.Freeze()
 
               $resourceColors = @{
-                  'AppBackgroundBrush'    = $colors.Background
-                  'SidebarBackgroundBrush' = $colors.SidebarBg
-                  'SidebarAccentBrush'    = $colors.Primary
-                  'SidebarHoverBrush'     = if ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } elseif ($colors.ContainsKey('Hover')) { $colors['Hover'] } else { $colors.Primary }
-                  'HeaderBackgroundBrush' = $colors.HeaderBg
-                  'HeaderBorderBrush'     = $cardBorderValue
-                  'CardBackgroundBrush'   = $colors.Secondary
-                  'CardBorderBrush'       = $cardBorderValue
-                  'AccentBrush'           = $colors.Primary
-                  'ButtonBackgroundBrush' = if ($colors.ContainsKey('ButtonBackground') -and $colors['ButtonBackground']) { $colors['ButtonBackground'] } else { $colors.Primary }
-                  'ButtonBorderBrush'     = if ($colors.ContainsKey('ButtonBorder') -and $colors['ButtonBorder']) { $colors['ButtonBorder'] } else { $colors.Primary }
-                  'ButtonHoverBrush'      = if ($colors.ContainsKey('ButtonHover') -and $colors['ButtonHover']) { $colors['ButtonHover'] } elseif ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } elseif ($colors.ContainsKey('Hover')) { $colors['Hover'] } else { $colors.Primary }
-                  'ButtonPressedBrush'    = if ($colors.ContainsKey('ButtonPressed') -and $colors['ButtonPressed']) { $colors['ButtonPressed'] } elseif ($colors.ContainsKey('Hover') -and $colors['Hover']) { $colors['Hover'] } else { $colors.Primary }
-                  'PrimaryTextBrush'      = $colors.Text
-                  'SecondaryTextBrush'    = $colors.TextSecondary
-                  'HeroChipBrush'         = if ($colors.ContainsKey('HeroChip') -and $colors['HeroChip']) { $colors['HeroChip'] } elseif ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } else { $colors.Accent }
-                  'SuccessBrush'          = if ($colors.ContainsKey('Success')) { $colors['Success'] } else { '#10B981' }
-                  'WarningBrush'          = if ($colors.ContainsKey('Warning')) { $colors['Warning'] } else { '#F59E0B' }
-                'DangerBrush'           = if ($colors.ContainsKey('Danger')) { $colors['Danger'] } else { '#EF4444' }
-                'InfoBrush'             = if ($colors.ContainsKey('Info')) { $colors['Info'] } else { $colors.Primary }
+                  'AppBackgroundBrush'             = $colors.Background
+                  'SidebarBackgroundBrush'         = $colors.SidebarBg
+                  'SidebarAccentBrush'             = $colors.Primary
+                  'SidebarHoverBrush'              = if ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } elseif ($colors.ContainsKey('Hover')) { $colors['Hover'] } else { $colors.Primary }
+                  'SidebarSelectedBrush'           = if ($colors.ContainsKey('SelectedBackground')) { $colors['SelectedBackground'] } else { $colors.Primary }
+                  'SidebarSelectedForegroundBrush' = if ($colors.ContainsKey('SelectedForeground')) { $colors['SelectedForeground'] } else { $colors.Text }
+                  'HeaderBackgroundBrush'          = $colors.HeaderBg
+                  'HeaderBorderBrush'              = $cardBorderValue
+                  'CardBackgroundBrush'            = $colors.Secondary
+                  'CardBorderBrush'                = $cardBorderValue
+                  'AccentBrush'                    = if ($colors.ContainsKey('Accent') -and $colors['Accent']) { $colors['Accent'] } else { $colors.Primary }
+                  'ButtonBackgroundBrush'          = if ($colors.ContainsKey('ButtonBackground') -and $colors['ButtonBackground']) { $colors['ButtonBackground'] } else { $colors.Primary }
+                  'ButtonBorderBrush'              = if ($colors.ContainsKey('ButtonBorder') -and $colors['ButtonBorder']) { $colors['ButtonBorder'] } else { $colors.Primary }
+                  'ButtonHoverBrush'               = if ($colors.ContainsKey('ButtonHover') -and $colors['ButtonHover']) { $colors['ButtonHover'] } elseif ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } elseif ($colors.ContainsKey('Hover')) { $colors['Hover'] } else { $colors.Primary }
+                  'ButtonPressedBrush'             = if ($colors.ContainsKey('ButtonPressed') -and $colors['ButtonPressed']) { $colors['ButtonPressed'] } elseif ($colors.ContainsKey('Hover') -and $colors['Hover']) { $colors['Hover'] } else { $colors.Primary }
+                  'PrimaryTextBrush'               = $colors.Text
+                  'SecondaryTextBrush'             = $colors.TextSecondary
+                  'HeroChipBrush'                  = if ($colors.ContainsKey('HeroChip') -and $colors['HeroChip']) { $colors['HeroChip'] } elseif ($colors.ContainsKey('HoverBackground') -and $colors['HoverBackground']) { $colors['HoverBackground'] } else { $colors.Accent }
+                  'SuccessBrush'                   = if ($colors.ContainsKey('Success')) { $colors['Success'] } else { '#10B981' }
+                  'WarningBrush'                   = if ($colors.ContainsKey('Warning')) { $colors['Warning'] } else { '#F59E0B' }
+                  'DangerBrush'                    = if ($colors.ContainsKey('Danger')) { $colors['Danger'] } else { '#EF4444' }
+                  'InfoBrush'                      = if ($colors.ContainsKey('Info')) { $colors['Info'] } else { $colors.Primary }
             }
 
             foreach ($resourceKey in $resourceColors.Keys) {
@@ -2775,9 +2777,9 @@ function Update-SystemHealthSummary {
             }
 
             switch ($status) {
-                'Excellent' { $foreground = '#5D5FEF' }
+                'Excellent' { $foreground = '#8F6FFF' }
                 'Good' { $foreground = '#A7F3D0' }
-                'Fair' { $foreground = '#A08BFF' }
+                'Fair' { $foreground = '#A78BFA' }
                 'Poor' { $foreground = '#FFA500' }
                 'Critical' { $foreground = '#FF6B6B' }
                 default { $foreground = '#A6AACF' }
@@ -2849,16 +2851,16 @@ function Show-SystemHealthDialog {
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="System Health Monitor"
         Width="750" Height="600"
-        Background="#0B0F1E"
+        Background="#080716"
         WindowStartupLocation="CenterScreen"
         ResizeMode="CanResize">
 
   <Window.Resources>
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#161D3F"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F3A73"/>
-    <SolidColorBrush x:Key="AccentBrush" Color="#5D5FEF"/>
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F6FF"/>
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#9AA4D9"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#14132B"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F285A"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#8F6FFF"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F3FF"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#A9A5D9"/>
     <Style TargetType="TextBlock">
       <Setter Property="FontFamily" Value="Segoe UI"/>
       <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}"/>
@@ -2866,7 +2868,7 @@ function Show-SystemHealthDialog {
     <Style x:Key="DialogButton" TargetType="Button">
       <Setter Property="FontFamily" Value="Segoe UI"/>
       <Setter Property="FontSize" Value="12"/>
-      <Setter Property="Foreground" Value="#0B0F1E"/>
+      <Setter Property="Foreground" Value="#120B22"/>
       <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
       <Setter Property="BorderThickness" Value="0"/>
       <Setter Property="Padding" Value="14,6"/>
@@ -2876,8 +2878,8 @@ function Show-SystemHealthDialog {
       <Setter Property="Background">
         <Setter.Value>
           <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-            <GradientStop Color="#3F6BFF" Offset="0"/>
-            <GradientStop Color="#2E4BD4" Offset="1"/>
+            <GradientStop Color="#8F6FFF" Offset="0"/>
+            <GradientStop Color="#B497FF" Offset="1"/>
           </LinearGradientBrush>
         </Setter.Value>
       </Setter>
@@ -2894,7 +2896,7 @@ function Show-SystemHealthDialog {
             <ControlTemplate.Triggers>
               <Trigger Property="IsMouseOver" Value="True">
 
-                <Setter Property="Background" Value="#7E7FFF"/>
+              <Setter Property="Background" Value="#A78BFA"/>
               </Trigger>
               <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value="0.4"/>
@@ -2905,12 +2907,12 @@ function Show-SystemHealthDialog {
       </Setter>
     </Style>
     <Style x:Key="SecondaryDialogButton" TargetType="Button" BasedOn="{StaticResource DialogButton}">
-      <Setter Property="Background" Value="#1B2345"/>
+      <Setter Property="Background" Value="#1F1B3F"/>
       <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}"/>
     </Style>
     <Style x:Key="WarningDialogButton" TargetType="Button" BasedOn="{StaticResource DialogButton}">
-      <Setter Property="Background" Value="#FFB347"/>
-      <Setter Property="Foreground" Value="#281C05"/>
+      <Setter Property="Background" Value="#FBBF24"/>
+      <Setter Property="Foreground" Value="#1B1302"/>
     </Style>
   </Window.Resources>
 
@@ -2952,7 +2954,7 @@ function Show-SystemHealthDialog {
 
         <StackPanel Grid.Column="0">
           <TextBlock Text="CPU Usage" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="12" FontWeight="Bold"/>
-          <TextBlock x:Name="lblCpuMetric" Text="--%" Foreground="#5D5FEF" FontSize="14" Margin="0,2,0,0"/>
+          <TextBlock x:Name="lblCpuMetric" Text="--%" Foreground="{DynamicResource AccentBrush}" FontSize="14" Margin="0,2,0,0"/>
         </StackPanel>
 
         <StackPanel Grid.Column="1">
@@ -3401,12 +3403,12 @@ function Show-LogSearchDialog {
         ResizeMode="CanResize">
 
   <Window.Resources>
-    <SolidColorBrush x:Key="DialogBackgroundBrush" Color="#0B0F1E"/>
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#161D3F"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F3A73"/>
-    <SolidColorBrush x:Key="AccentBrush" Color="#5D5FEF"/>
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F6FF"/>
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#9AA4D9"/>
+    <SolidColorBrush x:Key="DialogBackgroundBrush" Color="#080716"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#14132B"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F285A"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#8F6FFF"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F3FF"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#A9A5D9"/>
     <Style TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI"/>
         <Setter Property="FontSize" Value="12"/>
@@ -3423,7 +3425,7 @@ function Show-LogSearchDialog {
     <Style TargetType="Button" x:Key="DialogButton">
         <Setter Property="FontFamily" Value="Segoe UI"/>
         <Setter Property="FontSize" Value="12"/>
-        <Setter Property="Foreground" Value="#0B0F1E"/>
+        <Setter Property="Foreground" Value="#120B22"/>
         <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="14,6"/>
@@ -3437,7 +3439,7 @@ function Show-LogSearchDialog {
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#7E7FFF"/>
+                            <Setter Property="Background" Value="#A78BFA"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.4"/>
@@ -3448,12 +3450,12 @@ function Show-LogSearchDialog {
         </Setter>
     </Style>
     <Style x:Key="SecondaryDialogButton" TargetType="Button" BasedOn="{StaticResource DialogButton}">
-        <Setter Property="Background" Value="#1B2345"/>
+        <Setter Property="Background" Value="#1F1B3F"/>
         <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}"/>
     </Style>
     <Style x:Key="DangerDialogButton" TargetType="Button" BasedOn="{StaticResource DialogButton}">
-        <Setter Property="Background" Value="#F45B69"/>
-        <Setter Property="Foreground" Value="#FFFFFF"/>
+        <Setter Property="Background" Value="#F87171"/>
+        <Setter Property="Foreground" Value="#21060B"/>
     </Style>
   </Window.Resources>
 
@@ -3527,8 +3529,8 @@ function Show-LogSearchDialog {
                 <StackPanel>
                   <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{Binding Timestamp, StringFormat='yyyy-MM-dd HH:mm:ss'}" FontWeight="Bold" FontSize="10" Foreground="{DynamicResource AccentBrush}" Margin="0,0,10,0"/>
-                    <TextBlock Text="{Binding Level}" FontWeight="Bold" FontSize="10" Foreground="#5D5FEF" Margin="0,0,10,0"/>
-                    <TextBlock Text="{Binding Category}" FontSize="10" Foreground="#5D5FEF" Margin="0,0,0,0"/>
+                    <TextBlock Text="{Binding Level}" FontWeight="Bold" FontSize="10" Foreground="{DynamicResource AccentBrush}" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding Category}" FontSize="10" Foreground="{DynamicResource AccentBrush}" Margin="0,0,0,0"/>
                   </StackPanel>
                   <TextBlock Text="{Binding Message}" FontSize="11" Foreground="{DynamicResource PrimaryTextBrush}" Margin="0,3,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
@@ -3809,9 +3811,9 @@ function Update-DashboardMetrics {
                 if ($metrics.CpuUsage -ge 80) {
                     $lblDashCpuUsage.Foreground = "#FF4444"  # Red for high
                 } elseif ($metrics.CpuUsage -ge 60) {
-                    $lblDashCpuUsage.Foreground = "#A08BFF"  # Gold for medium
+                    $lblDashCpuUsage.Foreground = "#A78BFA"  # Purple for medium load
                 } else {
-                    $lblDashCpuUsage.Foreground = "#5D5FEF"  # Green for low
+                    $lblDashCpuUsage.Foreground = "#8F6FFF"  # Accent for low load
                 }
             })
         }
@@ -3825,9 +3827,9 @@ function Update-DashboardMetrics {
                 if ($metrics.MemoryUsagePercent -ge 85) {
                     $lblDashMemoryUsage.Foreground = "#FF4444"  # Red for high
                 } elseif ($metrics.MemoryUsagePercent -ge 70) {
-                    $lblDashMemoryUsage.Foreground = "#A08BFF"  # Gold for medium
+                    $lblDashMemoryUsage.Foreground = "#A78BFA"  # Purple for medium
                 } else {
-                    $lblDashMemoryUsage.Foreground = "#5D5FEF"  # Blue for normal
+                    $lblDashMemoryUsage.Foreground = "#8F6FFF"  # Accent for normal
                 }
             })
         }
@@ -3856,7 +3858,7 @@ function Update-DashboardMetrics {
             $lblDashActiveGames.Dispatcher.Invoke([Action]{
                 if ($metrics.ActiveGamesCount -gt 0) {
                     $lblDashActiveGames.Text = "$($metrics.ActiveGamesCount) running"
-                    $lblDashActiveGames.Foreground = "#5D5FEF"  # Green for active
+                    $lblDashActiveGames.Foreground = "#8F6FFF"  # Accent for active games
                 } else {
                     $lblDashActiveGames.Text = "None detected"
                     $lblDashActiveGames.Foreground = "#A6AACF"  # Default color
@@ -4064,7 +4066,7 @@ function Update-ActiveGamesTracking {
             $lblDashActiveGames.Dispatcher.Invoke([Action]{
                 if ($currentGames.Count -gt 0) {
                     $lblDashActiveGames.Text = "$($currentGames.Count) active"
-                    $lblDashActiveGames.Foreground = "#5D5FEF"
+                    $lblDashActiveGames.Foreground = "#8F6FFF"
                 } else {
                     $lblDashActiveGames.Text = "None active"
                     $lblDashActiveGames.Foreground = "#A6AACF"
@@ -4851,26 +4853,29 @@ $xamlContent = @'
         ResizeMode="CanResize"
         SizeToContent="Manual">
   <Window.Resources>
-    <SolidColorBrush x:Key="AppBackgroundBrush" Color="#1C1F26"/>
-    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#171A21"/>
-    <SolidColorBrush x:Key="SidebarAccentBrush" Color="#FF8C32"/>
-    <SolidColorBrush x:Key="SidebarHoverBrush" Color="#22262F"/>
-    <SolidColorBrush x:Key="HeaderBackgroundBrush" Color="#1F232B"/>
-    <SolidColorBrush x:Key="HeaderBorderBrush" Color="#2D313A"/>
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#21252E"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#2C303A"/>
-    <SolidColorBrush x:Key="HeroCardBrush" Color="#242932"/>
-    <SolidColorBrush x:Key="AccentBrush" Color="#FF8C32"/>
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F1F5F9"/>
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#9CA3AF"/>
-    <SolidColorBrush x:Key="SuccessBrush" Color="#22C55E"/>
-    <SolidColorBrush x:Key="WarningBrush" Color="#FACC15"/>
+    <SolidColorBrush x:Key="AppBackgroundBrush" Color="#080716"/>
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#0E0C21"/>
+    <SolidColorBrush x:Key="SidebarAccentBrush" Color="#8F6FFF"/>
+    <SolidColorBrush x:Key="SidebarHoverBrush" Color="#1F1B3F"/>
+    <SolidColorBrush x:Key="SidebarSelectedBrush" Color="#8F6FFF"/>
+    <SolidColorBrush x:Key="SidebarSelectedForegroundBrush" Color="#F5F3FF"/>
+    <SolidColorBrush x:Key="HeaderBackgroundBrush" Color="#151233"/>
+    <SolidColorBrush x:Key="HeaderBorderBrush" Color="#2F285A"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#14132B"/>
+    <SolidColorBrush x:Key="ContentBackgroundBrush" Color="#19173A"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F285A"/>
+    <SolidColorBrush x:Key="HeroCardBrush" Color="#1F1B40"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#B497FF"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F3FF"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#A9A5D9"/>
+    <SolidColorBrush x:Key="SuccessBrush" Color="#34D399"/>
+    <SolidColorBrush x:Key="WarningBrush" Color="#FBBF24"/>
     <SolidColorBrush x:Key="DangerBrush" Color="#F87171"/>
-    <SolidColorBrush x:Key="InfoBrush" Color="#38BDF8"/>
-    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#2D323C"/>
-    <SolidColorBrush x:Key="ButtonBorderBrush" Color="#353A45"/>
-    <SolidColorBrush x:Key="ButtonHoverBrush" Color="#353B47"/>
-    <SolidColorBrush x:Key="ButtonPressedBrush" Color="#2A303A"/>
+    <SolidColorBrush x:Key="InfoBrush" Color="#60A5FA"/>
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#1E1B38"/>
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="#2A264B"/>
+    <SolidColorBrush x:Key="ButtonHoverBrush" Color="#282450"/>
+    <SolidColorBrush x:Key="ButtonPressedBrush" Color="#1A1839"/>
 
 
     <Style x:Key="BaseControlStyle" TargetType="Control">
@@ -4968,7 +4973,7 @@ $xamlContent = @'
 
     <Style x:Key="SidebarButton" TargetType="Button" BasedOn="{StaticResource BaseControlStyle}">
       <Setter Property="Background" Value="Transparent"/>
-      <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
+      <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
       <Setter Property="BorderThickness" Value="0"/>
       <Setter Property="Padding" Value="14,10"/>
       <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -4985,8 +4990,8 @@ $xamlContent = @'
                 <Setter TargetName="sidebarBg" Property="Background" Value="{DynamicResource SidebarHoverBrush}"/>
               </Trigger>
               <Trigger Property="Tag" Value="Selected">
-                <Setter TargetName="sidebarBg" Property="Background" Value="#2A2E38"/>
-                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+                <Setter TargetName="sidebarBg" Property="Background" Value="{DynamicResource SidebarSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource SidebarSelectedForegroundBrush}"/>
               </Trigger>
               <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value="0.5"/>
@@ -5011,9 +5016,9 @@ $xamlContent = @'
     </Style>
 
     <Style x:Key="ModernComboBox" TargetType="ComboBox" BasedOn="{StaticResource BaseControlStyle}">
-      <Setter Property="Background" Value="#1F232B"/>
+      <Setter Property="Background" Value="{DynamicResource ContentBackgroundBrush}"/>
       <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
-      <Setter Property="BorderBrush" Value="#323741"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
       <Setter Property="BorderThickness" Value="1"/>
       <Setter Property="Padding" Value="10,6"/>
       <Setter Property="Height" Value="34"/>
@@ -5024,11 +5029,11 @@ $xamlContent = @'
           <Setter Property="Padding" Value="12,6"/>
           <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-              <Setter Property="Background" Value="#2B303A"/>
+              <Setter Property="Background" Value="{DynamicResource SidebarHoverBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
               <Setter Property="Background" Value="{DynamicResource SidebarAccentBrush}"/>
-              <Setter Property="Foreground" Value="#1C1208"/>
+              <Setter Property="Foreground" Value="{DynamicResource SidebarSelectedForegroundBrush}"/>
             </Trigger>
           </Style.Triggers>
         </Style>
@@ -5036,9 +5041,9 @@ $xamlContent = @'
     </Style>
 
     <Style x:Key="ModernTextBox" TargetType="TextBox" BasedOn="{StaticResource BaseControlStyle}">
-      <Setter Property="Background" Value="#1F232B"/>
+      <Setter Property="Background" Value="{DynamicResource ContentBackgroundBrush}"/>
       <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
-      <Setter Property="BorderBrush" Value="#323741"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
       <Setter Property="BorderThickness" Value="1"/>
       <Setter Property="Padding" Value="10,6"/>
       <Setter Property="Height" Value="32"/>
@@ -5144,8 +5149,8 @@ $xamlContent = @'
 
         <Border x:Name="SidebarAdminCard"
                 Grid.Row="2"
-                Background="#1D2027"
-                BorderBrush="#272B34"
+                Background="{DynamicResource ContentBackgroundBrush}"
+                BorderBrush="{DynamicResource CardBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="8"
                 Padding="14"
@@ -5183,19 +5188,19 @@ $xamlContent = @'
             <TextBlock x:Name="lblMainSubtitle" Text="Your system at a glance" Style="{StaticResource SectionSubtext}" Margin="0,4,0,0"/>
           </StackPanel>
           <StackPanel Grid.Column="1" Orientation="Horizontal" Tag="Spacing:12">
-            <Border Background="#262B34" CornerRadius="8" Padding="14" MinWidth="100">
+            <Border Background="{DynamicResource ContentBackgroundBrush}" CornerRadius="8" Padding="14" MinWidth="100" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
               <StackPanel>
                 <TextBlock Text="Profiles" Style="{StaticResource SectionSubtext}"/>
                 <TextBlock x:Name="lblHeroProfiles" Style="{StaticResource MetricValue}" Text="--"/>
               </StackPanel>
             </Border>
-            <Border Background="#262B34" CornerRadius="8" Padding="14" MinWidth="120">
+            <Border Background="{DynamicResource ContentBackgroundBrush}" CornerRadius="8" Padding="14" MinWidth="120" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
               <StackPanel>
                 <TextBlock Text="Optimizations" Style="{StaticResource SectionSubtext}"/>
                 <TextBlock x:Name="lblHeroOptimizations" Style="{StaticResource MetricValue}" Text="--"/>
               </StackPanel>
             </Border>
-            <Border Background="#262B34" CornerRadius="8" Padding="14" MinWidth="120">
+            <Border Background="{DynamicResource ContentBackgroundBrush}" CornerRadius="8" Padding="14" MinWidth="120" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
               <StackPanel>
                 <TextBlock Text="Auto mode" Style="{StaticResource SectionSubtext}"/>
                 <TextBlock x:Name="lblHeroAutoMode" Style="{StaticResource MetricValue}" Text="Off"/>
@@ -5225,7 +5230,7 @@ $xamlContent = @'
                   <TextBlock Text="KOALA keeps your PC lean with smart maintenance, clean logging and one-click fixes." Style="{StaticResource SectionSubtext}"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1" HorizontalAlignment="Right" Tag="Spacing:12">
-                  <Border Background="#1E2128" CornerRadius="10" Padding="14" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
+                  <Border Background="{DynamicResource ContentBackgroundBrush}" CornerRadius="10" Padding="14" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
                     <StackPanel>
                       <TextBlock Text="Last run" Style="{StaticResource SectionSubtext}"/>
                       <TextBlock x:Name="lblHeaderLastRun" Text="Never" Style="{StaticResource MetricValue}" FontSize="18"/>
@@ -5249,31 +5254,31 @@ $xamlContent = @'
                   <ColumnDefinition Width="*"/>
                   <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <Border x:Name="dashboardCpuCard" Background="#1E222A" CornerRadius="10" Padding="16" BorderBrush="#2A2E38" BorderThickness="1">
+                <Border x:Name="dashboardCpuCard" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="10" Padding="16" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
                   <StackPanel Tag="Spacing:6">
                     <TextBlock Text="CPU load" Style="{StaticResource SectionSubtext}" FontSize="13"/>
                     <TextBlock x:Name="lblDashCpuUsage" Style="{StaticResource MetricValue}" Text="--%"/>
                     <TextBlock Text="Realtime usage of each core." Style="{StaticResource SectionSubtext}"/>
                   </StackPanel>
                 </Border>
-                <Border x:Name="dashboardMemoryCard" Grid.Column="1" Background="#1E222A" CornerRadius="10" Padding="16" BorderBrush="#2A2E38" BorderThickness="1">
+                <Border x:Name="dashboardMemoryCard" Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="10" Padding="16" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
                   <StackPanel Tag="Spacing:6">
                     <TextBlock Text="Memory" Style="{StaticResource SectionSubtext}" FontSize="13"/>
-                    <TextBlock x:Name="lblDashMemoryUsage" Style="{StaticResource MetricValue}" Text="-- / -- GB" Foreground="#60A5FA"/>
+                    <TextBlock x:Name="lblDashMemoryUsage" Style="{StaticResource MetricValue}" Text="-- / -- GB" Foreground="{DynamicResource AccentBrush}"/>
                     <TextBlock Text="Track system memory consumption." Style="{StaticResource SectionSubtext}"/>
                   </StackPanel>
                 </Border>
-                <Border x:Name="dashboardActivityCard" Grid.Column="2" Background="#1E222A" CornerRadius="10" Padding="16" BorderBrush="#2A2E38" BorderThickness="1">
+                <Border x:Name="dashboardActivityCard" Grid.Column="2" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="10" Padding="16" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
                   <StackPanel Tag="Spacing:6">
                     <TextBlock Text="Session" Style="{StaticResource SectionSubtext}" FontSize="13"/>
                     <TextBlock Text="Active games" Style="{StaticResource SectionSubtext}"/>
                     <TextBlock x:Name="lblDashActiveGames" Style="{StaticResource MetricValue}" Text="None"/>
-                    <Separator Margin="0,4" Background="#2E3441" Height="1"/>
+                    <Separator Margin="0,4" Background="{DynamicResource CardBorderBrush}" Height="1"/>
                     <TextBlock Text="Last optimization" Style="{StaticResource SectionSubtext}"/>
                     <TextBlock x:Name="lblDashLastOptimization" Style="{StaticResource SectionSubtext}" FontSize="13" Text="Never"/>
                   </StackPanel>
                 </Border>
-                <Border x:Name="dashboardHealthCard" Grid.Column="3" Background="#1E222A" CornerRadius="10" Padding="16" BorderBrush="#2A2E38" BorderThickness="1">
+                <Border x:Name="dashboardHealthCard" Grid.Column="3" Background="{DynamicResource CardBackgroundBrush}" CornerRadius="10" Padding="16" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1">
                   <StackPanel Tag="Spacing:8">
                     <TextBlock Text="System health" Style="{StaticResource SectionSubtext}" FontSize="13"/>
                     <TextBlock x:Name="lblDashSystemHealth" Style="{StaticResource MetricValue}" Text="Not run"/>
@@ -5404,10 +5409,10 @@ $xamlContent = @'
                   <Button x:Name="btnAdvancedServices" Content="🛠️ Services" Style="{StaticResource ModernButton}" MinWidth="120" Height="32" FontSize="12"/>
                 </StackPanel>
 
-                <Expander x:Name="expanderNetworkTweaks" Header="🌐 Network optimizations" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10">
+                <Expander x:Name="expanderNetworkTweaks" Header="🌐 Network optimizations" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Fine tune TCP and latency for competitive play." Style="{StaticResource SectionSubtext}"/>
-                    <Expander x:Name="expanderNetworkOptimizations" Header="Core network tweaks" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10" IsExpanded="True">
+                    <Expander x:Name="expanderNetworkOptimizations" Header="Core network tweaks" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10" IsExpanded="True">
                       <WrapPanel>
                         <CheckBox x:Name="chkAckNetwork" Content="TCP ACK Frequency" Style="{StaticResource ModernCheckBox}"/>
                         <CheckBox x:Name="chkDelAckTicksNetwork" Content="Delayed ACK Ticks" Style="{StaticResource ModernCheckBox}"/>
@@ -5421,7 +5426,7 @@ $xamlContent = @'
                         <CheckBox x:Name="chkTcpWindowAutoTuningNetwork" Content="Window auto tuning" Style="{StaticResource ModernCheckBox}"/>
                       </WrapPanel>
                     </Expander>
-                    <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="14">
+                    <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="14">
                       <Grid Tag="ColumnSpacing:12">
                         <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="*"/>
@@ -5436,10 +5441,10 @@ $xamlContent = @'
                   </StackPanel>
                 </Expander>
 
-                <Expander x:Name="expanderSystemOptimizations" Header="💻 System optimizations" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10">
+                <Expander x:Name="expanderSystemOptimizations" Header="💻 System optimizations" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Performance and hardware adjustments for maximum efficiency." Style="{StaticResource SectionSubtext}"/>
-                    <Expander x:Name="expanderPerformanceOptimizations" Header="Performance essentials" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10" IsExpanded="True">
+                    <Expander x:Name="expanderPerformanceOptimizations" Header="Performance essentials" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10" IsExpanded="True">
                       <WrapPanel>
                         <CheckBox x:Name="chkMemoryCompressionSystem" Content="Memory compression" Style="{StaticResource ModernCheckBox}"/>
                         <CheckBox x:Name="chkPowerPlanSystem" Content="High performance plan" Style="{StaticResource ModernCheckBox}"/>
@@ -5456,7 +5461,7 @@ $xamlContent = @'
                       </WrapPanel>
                     </Expander>
 
-                    <Expander x:Name="expanderAdvancedPerformance" Header="Advanced enhancements" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10">
+                    <Expander x:Name="expanderAdvancedPerformance" Header="Advanced enhancements" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10">
                       <WrapPanel>
                         <CheckBox x:Name="chkDynamicResolution" Content="Dynamic resolution" Style="{StaticResource ModernCheckBox}"/>
                         <CheckBox x:Name="chkEnhancedFramePacing" Content="Enhanced frame pacing" Style="{StaticResource ModernCheckBox}"/>
@@ -5477,7 +5482,7 @@ $xamlContent = @'
                       </WrapPanel>
                     </Expander>
 
-                    <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="14">
+                    <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="14">
                       <Grid Tag="ColumnSpacing:12">
                         <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="*"/>
@@ -5492,10 +5497,10 @@ $xamlContent = @'
                   </StackPanel>
                 </Expander>
 
-                <Expander x:Name="expanderServiceManagement" Header="🛠️ Service optimizations" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10">
+                <Expander x:Name="expanderServiceManagement" Header="🛠️ Service optimizations" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Manage background services for better responsiveness." Style="{StaticResource SectionSubtext}"/>
-                    <Expander x:Name="expanderServiceOptimizations" Header="Service tweaks" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10" IsExpanded="True">
+                    <Expander x:Name="expanderServiceOptimizations" Header="Service tweaks" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10" IsExpanded="True">
                       <WrapPanel>
                         <CheckBox x:Name="chkDisableXboxServicesServices" Content="Disable Xbox services" Style="{StaticResource ModernCheckBox}"/>
                         <CheckBox x:Name="chkDisableTelemetryServices" Content="Disable telemetry" Style="{StaticResource ModernCheckBox}"/>
@@ -5507,7 +5512,7 @@ $xamlContent = @'
                         <CheckBox x:Name="chkDisableThemesServices" Content="Optimize themes service" Style="{StaticResource ModernCheckBox}"/>
                       </WrapPanel>
                     </Expander>
-                    <Expander x:Name="expanderPrivacyServices" Header="Privacy &amp; background" Background="#1C1F26" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="#2C303A" BorderThickness="1" Padding="10">
+                    <Expander x:Name="expanderPrivacyServices" Header="Privacy &amp; background" Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" Padding="10">
                       <WrapPanel>
                         <CheckBox x:Name="chkDisableCortana" Content="Disable Cortana" Style="{StaticResource ModernCheckBox}"/>
                         <CheckBox x:Name="chkDisableWindowsUpdate" Content="Optimize Windows Update" Style="{StaticResource ModernCheckBox}"/>
@@ -5519,7 +5524,7 @@ $xamlContent = @'
                         <CheckBox x:Name="chkDisableWSH" Content="Disable Windows Script Host" Style="{StaticResource ModernCheckBox}"/>
                       </WrapPanel>
                     </Expander>
-                    <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="14">
+                    <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="14">
                       <Grid Tag="ColumnSpacing:12">
                         <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="*"/>
@@ -5541,7 +5546,7 @@ $xamlContent = @'
             <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="22">
               <StackPanel Tag="Spacing:16">
                 <TextBlock Text="Installed games" Style="{StaticResource SectionHeader}" FontSize="18"/>
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Detection &amp; search" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <Grid Tag="ColumnSpacing:12">
@@ -5556,7 +5561,7 @@ $xamlContent = @'
                     </Grid>
                   </StackPanel>
                 </Border>
-                <Border x:Name="installedGamesPanel" Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border x:Name="installedGamesPanel" Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Detected games" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <ScrollViewer Height="280" VerticalScrollBarVisibility="Auto">
@@ -5575,7 +5580,7 @@ $xamlContent = @'
             <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="22">
               <StackPanel Tag="Spacing:16">
                 <TextBlock Text="Theme &amp; preferences" Style="{StaticResource SectionHeader}" FontSize="18" HorizontalAlignment="Center"/>
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Theme" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <Grid Tag="ColumnSpacing:10">
@@ -5602,7 +5607,7 @@ $xamlContent = @'
                       <Button x:Name="btnOptionsApplyThemeMain" Grid.Column="2" Content="Apply" Width="90" Height="32" Style="{StaticResource SuccessButton}" FontSize="12"/>
                       <Button x:Name="btnApplyTheme" Visibility="Collapsed" Width="0" Height="0"/>
                     </Grid>
-                    <Border x:Name="themeColorPreview" Background="#1A1D24" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="6" Padding="12">
+                    <Border x:Name="themeColorPreview" Background="{DynamicResource ContentBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="12">
                       <Grid Tag="ColumnSpacing:10">
                         <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="*"/>
@@ -5612,26 +5617,26 @@ $xamlContent = @'
                         </Grid.ColumnDefinitions>
                         <StackPanel>
                           <TextBlock Text="Background" Style="{StaticResource SectionSubtext}" FontSize="11" HorizontalAlignment="Center"/>
-                          <Rectangle x:Name="previewBg" Height="20" Fill="#1C1F26" Stroke="#394150" StrokeThickness="1"/>
+                          <Rectangle x:Name="previewBg" Height="20" Fill="{DynamicResource CardBackgroundBrush}" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1"/>
                         </StackPanel>
                         <StackPanel Grid.Column="1">
                           <TextBlock Text="Primary" Style="{StaticResource SectionSubtext}" FontSize="11" HorizontalAlignment="Center"/>
-                          <Rectangle x:Name="previewPrimary" Height="20" Fill="#FF8C32" Stroke="#394150" StrokeThickness="1"/>
+                          <Rectangle x:Name="previewPrimary" Height="20" Fill="#8F6FFF" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1"/>
                         </StackPanel>
                         <StackPanel Grid.Column="2">
                           <TextBlock Text="Hover" Style="{StaticResource SectionSubtext}" FontSize="11" HorizontalAlignment="Center"/>
-                          <Rectangle x:Name="previewHover" Height="20" Fill="#FF9D54" Stroke="#394150" StrokeThickness="1"/>
+                          <Rectangle x:Name="previewHover" Height="20" Fill="#A78BFA" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1"/>
                         </StackPanel>
                         <StackPanel Grid.Column="3">
                           <TextBlock Text="Text" Style="{StaticResource SectionSubtext}" FontSize="11" HorizontalAlignment="Center"/>
-                          <Rectangle x:Name="previewText" Height="20" Fill="#F8FAFC" Stroke="#394150" StrokeThickness="1"/>
+                          <Rectangle x:Name="previewText" Height="20" Fill="#F5F3FF" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1"/>
                         </StackPanel>
                       </Grid>
                     </Border>
                   </StackPanel>
                 </Border>
 
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:10">
                     <TextBlock x:Name="lblLanguageSectionTitle" Text="Language" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <TextBlock x:Name="lblLanguageDescription" Text="Choose how KOALA talks to you." Style="{StaticResource SectionSubtext}"/>
@@ -5649,7 +5654,7 @@ $xamlContent = @'
                   </StackPanel>
                 </Border>
 
-                <Border x:Name="customThemePanel" Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16" Visibility="Collapsed">
+                <Border x:Name="customThemePanel" Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16" Visibility="Collapsed">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Custom colors" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <Grid Tag="ColumnSpacing:12">
@@ -5661,22 +5666,22 @@ $xamlContent = @'
                       </Grid.ColumnDefinitions>
                       <StackPanel>
                         <TextBlock Text="Background" Style="{StaticResource SectionSubtext}" FontSize="11"/>
-                        <Rectangle x:Name="previewBgCustom" Height="22" Width="70" Fill="#1C1F26" Stroke="#394150" StrokeThickness="1" Margin="0,4,0,0"/>
+                        <Rectangle x:Name="previewBgCustom" Height="22" Width="70" Fill="{DynamicResource CardBackgroundBrush}" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1" Margin="0,4,0,0"/>
                         <TextBox x:Name="txtCustomBg" Style="{StaticResource ModernTextBox}" Margin="0,6,0,0"/>
                       </StackPanel>
                       <StackPanel Grid.Column="1">
                         <TextBlock Text="Primary" Style="{StaticResource SectionSubtext}" FontSize="11"/>
-                        <Rectangle x:Name="previewPrimaryCustom" Height="22" Width="70" Fill="#FF8C32" Stroke="#394150" StrokeThickness="1" Margin="0,4,0,0"/>
+                        <Rectangle x:Name="previewPrimaryCustom" Height="22" Width="70" Fill="#8F6FFF" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1" Margin="0,4,0,0"/>
                         <TextBox x:Name="txtCustomPrimary" Style="{StaticResource ModernTextBox}" Margin="0,6,0,0"/>
                       </StackPanel>
                       <StackPanel Grid.Column="2">
                         <TextBlock Text="Hover" Style="{StaticResource SectionSubtext}" FontSize="11"/>
-                        <Rectangle x:Name="previewHoverCustom" Height="22" Width="70" Fill="#FF9D54" Stroke="#394150" StrokeThickness="1" Margin="0,4,0,0"/>
+                        <Rectangle x:Name="previewHoverCustom" Height="22" Width="70" Fill="#A78BFA" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1" Margin="0,4,0,0"/>
                         <TextBox x:Name="txtCustomHover" Style="{StaticResource ModernTextBox}" Margin="0,6,0,0"/>
                       </StackPanel>
                       <StackPanel Grid.Column="3">
                         <TextBlock Text="Text" Style="{StaticResource SectionSubtext}" FontSize="11"/>
-                        <Rectangle x:Name="previewTextCustom" Height="22" Width="70" Fill="#F8FAFC" Stroke="#394150" StrokeThickness="1" Margin="0,4,0,0"/>
+                        <Rectangle x:Name="previewTextCustom" Height="22" Width="70" Fill="#F5F3FF" Stroke="{DynamicResource CardBorderBrush}" StrokeThickness="1" Margin="0,4,0,0"/>
                         <TextBox x:Name="txtCustomText" Style="{StaticResource ModernTextBox}" Margin="0,6,0,0"/>
                       </StackPanel>
                     </Grid>
@@ -5684,7 +5689,7 @@ $xamlContent = @'
                   </StackPanel>
                 </Border>
 
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:10">
                     <TextBlock Text="UI scaling" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <Grid Tag="ColumnSpacing:10">
@@ -5704,7 +5709,7 @@ $xamlContent = @'
                   </StackPanel>
                 </Border>
 
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:10">
                     <TextBlock Text="Settings management" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <Grid Tag="ColumnSpacing:10">
@@ -5727,7 +5732,7 @@ $xamlContent = @'
             <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="22">
               <StackPanel Tag="Spacing:16">
                 <TextBlock Text="Backup and restore" Style="{StaticResource SectionHeader}" FontSize="18" HorizontalAlignment="Center"/>
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Create backup" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <TextBlock Text="Store your optimizations and settings to a safe location." Style="{StaticResource SectionSubtext}"/>
@@ -5741,7 +5746,7 @@ $xamlContent = @'
                     </Grid>
                   </StackPanel>
                 </Border>
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Restore" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <TextBlock Text="Import existing configurations or restore from a backup file." Style="{StaticResource SectionSubtext}"/>
@@ -5755,7 +5760,7 @@ $xamlContent = @'
                     </Grid>
                   </StackPanel>
                 </Border>
-                <Border Background="#1C1F26" BorderBrush="#2C303A" BorderThickness="1" CornerRadius="8" Padding="16">
+                <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="16">
                   <StackPanel Tag="Spacing:12">
                     <TextBlock Text="Activity log" Style="{StaticResource SectionSubtext}" FontSize="14"/>
                     <TextBlock Text="Export or clear your optimization history." Style="{StaticResource SectionSubtext}"/>
@@ -7184,7 +7189,7 @@ $headerItem.Content = "--- COMPETITIVE SHOOTERS ---"
 $headerItem.Tag = ""
 $headerItem.IsEnabled = $false
 $headerItem.FontWeight = "Bold"
-$headerItem.Foreground = "#A08BFF"
+$headerItem.Foreground = "#8F6FFF"
 $cmbGameProfile.Items.Add($headerItem)
 
 foreach ($key in @('cs2', 'csgo', 'valorant', 'overwatch2', 'r6siege')) {
@@ -7202,7 +7207,7 @@ $headerItem.Content = "--- BATTLE ROYALE ---"
 $headerItem.Tag = ""
 $headerItem.IsEnabled = $false
 $headerItem.FontWeight = "Bold"
-$headerItem.Foreground = "#A08BFF"
+$headerItem.Foreground = "#8F6FFF"
 $cmbGameProfile.Items.Add($headerItem)
 
 foreach ($key in @('fortnite', 'apexlegends', 'pubg', 'warzone')) {
@@ -7220,7 +7225,7 @@ $headerItem.Content = "--- MULTIPLAYER ---"
 $headerItem.Tag = ""
 $headerItem.IsEnabled = $false
 $headerItem.FontWeight = "Bold"
-$headerItem.Foreground = "#A08BFF"
+$headerItem.Foreground = "#8F6FFF"
 $cmbGameProfile.Items.Add($headerItem)
 
 foreach ($key in @('lol', 'rocketleague', 'dota2', 'gta5')) {
@@ -7238,7 +7243,7 @@ $headerItem.Content = "--- AAA TITLES ---"
 $headerItem.Tag = ""
 $headerItem.IsEnabled = $false
 $headerItem.FontWeight = "Bold"
-$headerItem.Foreground = "#A08BFF"
+$headerItem.Foreground = "#8F6FFF"
 $cmbGameProfile.Items.Add($headerItem)
 
 foreach ($key in @('hogwartslegacy', 'starfield', 'baldursgate3', 'cyberpunk2077')) {
@@ -7256,7 +7261,7 @@ $headerItem.Content = "--- SURVIVAL & MORE ---"
 $headerItem.Tag = ""
 $headerItem.IsEnabled = $false
 $headerItem.FontWeight = "Bold"
-$headerItem.Foreground = "#A08BFF"
+$headerItem.Foreground = "#8F6FFF"
 $cmbGameProfile.Items.Add($headerItem)
 
 foreach ($key in $GameProfiles.Keys | Where-Object { $_ -notin @('cs2', 'csgo', 'valorant', 'overwatch2', 'r6siege', 'fortnite', 'apexlegends', 'pubg', 'warzone', 'lol', 'rocketleague', 'dota2', 'gta5', 'hogwartslegacy', 'starfield', 'baldursgate3', 'cyberpunk2077') }) {
@@ -7446,12 +7451,12 @@ function Show-InstalledGames {
         ResizeMode="CanResize">
 
   <Window.Resources>
-    <SolidColorBrush x:Key="DialogBackgroundBrush" Color="#0B0F1E"/>
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#161D3F"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F3A73"/>
-    <SolidColorBrush x:Key="AccentBrush" Color="#5D5FEF"/>
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F6FF"/>
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#9AA4D9"/>
+    <SolidColorBrush x:Key="DialogBackgroundBrush" Color="#080716"/>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#14132B"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#2F285A"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#8F6FFF"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#F5F3FF"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#A9A5D9"/>
     <Style TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI"/>
         <Setter Property="FontSize" Value="12"/>
@@ -7460,7 +7465,7 @@ function Show-InstalledGames {
     <Style TargetType="Button" x:Key="DialogButton">
         <Setter Property="FontFamily" Value="Segoe UI"/>
         <Setter Property="FontSize" Value="12"/>
-        <Setter Property="Foreground" Value="#0B0F1E"/>
+        <Setter Property="Foreground" Value="#120B22"/>
         <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="14,6"/>
@@ -7474,7 +7479,7 @@ function Show-InstalledGames {
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#7E7FFF"/>
+                            <Setter Property="Background" Value="#A78BFA"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.4"/>
@@ -7485,7 +7490,7 @@ function Show-InstalledGames {
         </Setter>
     </Style>
     <Style x:Key="SecondaryDialogButton" TargetType="Button" BasedOn="{StaticResource DialogButton}">
-        <Setter Property="Background" Value="#1B2345"/>
+        <Setter Property="Background" Value="#1F1B3F"/>
         <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}"/>
     </Style>
   </Window.Resources>
@@ -7514,8 +7519,8 @@ function Show-InstalledGames {
               <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="4" Padding="8" Margin="2">
                 <StackPanel>
                   <TextBlock Text="{Binding Name}" FontWeight="Bold" FontSize="13" Foreground="{DynamicResource AccentBrush}"/>
-                  <TextBlock Text="{Binding Path}" FontSize="11" Foreground="#B8B8B8" Margin="0,2,0,0"/>
-                  <TextBlock Text="{Binding Details}" FontSize="10" Foreground="#5D5FEF" Margin="0,2,0,0"/>
+                  <TextBlock Text="{Binding Path}" FontSize="11" Foreground="{DynamicResource SecondaryTextBrush}" Margin="0,2,0,0"/>
+                  <TextBlock Text="{Binding Details}" FontSize="10" Foreground="{DynamicResource AccentBrush}" Margin="0,2,0,0"/>
                 </StackPanel>
               </Border>
             </DataTemplate>
@@ -7528,7 +7533,7 @@ function Show-InstalledGames {
     <Border Grid.Row="2" Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="2" CornerRadius="8" Padding="10" Margin="0,15,0,0">
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
         <Button x:Name="btnRefreshGames" Content="Refresh Search" Width="140" Height="34" Style="{StaticResource DialogButton}" Margin="0,0,10,0"/>
-        <Button x:Name="btnCloseGames" Content="Close" Width="80" Height="32" Background="#A06CFF" Foreground="{DynamicResource PrimaryTextBrush}" BorderThickness="0" FontWeight="SemiBold"/>
+        <Button x:Name="btnCloseGames" Content="Close" Width="80" Height="32" Background="{DynamicResource AccentBrush}" Foreground="{DynamicResource PrimaryTextBrush}" BorderThickness="0" FontWeight="SemiBold"/>
       </StackPanel>
     </Border>
   </Grid>
@@ -7943,7 +7948,7 @@ function Search-GamesForPanel {
         # Add loading message
         $loadingText = New-Object System.Windows.Controls.TextBlock
         try { $loadingText.Text = "🔍 Searching for installed games with advanced detection..." } catch { Write-Verbose "Text assignment skipped for compatibility" }
-        try { $loadingText.Foreground = "#5D5FEF" } catch { Write-Verbose "Foreground assignment skipped for compatibility" }
+        try { $loadingText.Foreground = "#8F6FFF" } catch { Write-Verbose "Foreground assignment skipped for compatibility" }
         try { $loadingText.FontStyle = "Italic" } catch { Write-Verbose "FontStyle assignment skipped for compatibility" }
         try { $loadingText.HorizontalAlignment = "Center" } catch { Write-Verbose "HorizontalAlignment assignment skipped for compatibility" }
         try { $loadingText.Margin = "0,20" } catch { Write-Verbose "Margin assignment skipped for compatibility" }
@@ -8067,7 +8072,7 @@ function Search-GamesForPanel {
             # Add header
             $headerText = New-Object System.Windows.Controls.TextBlock
             $headerText.Text = "✅ Found $($foundGames.Count) installed games:"
-            $headerText.Foreground = "#5D5FEF"
+            $headerText.Foreground = "#8F6FFF"
             $headerText.FontWeight = "Bold"
             $headerText.Margin = "0,0,0,10"
             $gameListPanel.Children.Add($headerText)
@@ -8075,9 +8080,9 @@ function Search-GamesForPanel {
             # Add games with checkboxes
             foreach ($game in $foundGames) {
                 $gameContainer = New-Object System.Windows.Controls.Border
-                $gameContainer.Background = "#1A1F39"
+                $gameContainer.Background = "#14132B"
                 try {
-                    $gameContainer.BorderBrush = "#2F3A73"
+                    $gameContainer.BorderBrush = "#2F285A"
                     $gameContainer.BorderThickness = "1"
                 } catch {
                     Write-Verbose "BorderBrush assignment skipped for .NET Framework 4.8 compatibility"
@@ -8099,13 +8104,13 @@ function Search-GamesForPanel {
 
                 $gameNameText = New-Object System.Windows.Controls.TextBlock
                 $gameNameText.Text = $game.Name
-                $gameNameText.Foreground = "#5D5FEF"
+                $gameNameText.Foreground = "#8F6FFF"
                 $gameNameText.FontWeight = "Bold"
                 $gameNameText.FontSize = "12"
 
                 $gamePathText = New-Object System.Windows.Controls.TextBlock
                 $gamePathText.Text = $game.Path
-                $gamePathText.Foreground = "#B8B8B8"
+                $gamePathText.Foreground = "#A9A5D9"
                 $gamePathText.FontSize = "10"
                 $gamePathText.TextWrapping = "Wrap"
 
@@ -8165,7 +8170,7 @@ function Search-CustomFoldersForExecutables {
         # Add loading message
         $loadingText = New-Object System.Windows.Controls.TextBlock
         try { $loadingText.Text = "🔍 Scanning custom folders for .exe files..." } catch { Write-Verbose "Text assignment skipped for compatibility" }
-        try { $loadingText.Foreground = "#A08BFF" } catch { Write-Verbose "Foreground assignment skipped for compatibility" }
+        try { $loadingText.Foreground = "#8F6FFF" } catch { Write-Verbose "Foreground assignment skipped for compatibility" }
         try { $loadingText.FontStyle = "Italic" } catch { Write-Verbose "FontStyle assignment skipped for compatibility" }
         try { $loadingText.HorizontalAlignment = "Center" } catch { Write-Verbose "HorizontalAlignment assignment skipped for compatibility" }
         try { $loadingText.Margin = "0,20" } catch { Write-Verbose "Margin assignment skipped for compatibility" }
@@ -8236,7 +8241,7 @@ function Search-CustomFoldersForExecutables {
             # Add header
             $headerText = New-Object System.Windows.Controls.TextBlock
             $headerText.Text = "🔍 Found $($foundExecutables.Count) executable(s) in custom folders - Select any to optimize:"
-            $headerText.Foreground = "#A08BFF"
+            $headerText.Foreground = "#8F6FFF"
             $headerText.FontWeight = "Bold"
             $headerText.FontSize = 12
             $headerText.Margin = "0,0,0,8"
@@ -8249,9 +8254,9 @@ function Search-CustomFoldersForExecutables {
             foreach ($executable in $foundExecutables) {
                 # Create container border
                 $border = New-Object System.Windows.Controls.Border
-                $border.Background = "#1E233E"
+                $border.Background = "#14132B"
                 try {
-                    $border.BorderBrush = "#2F3A73"
+                    $border.BorderBrush = "#2F285A"
                     $border.BorderThickness = "1"
                 } catch {
                     Write-Verbose "BorderBrush assignment skipped for .NET Framework 4.8 compatibility"
@@ -8264,7 +8269,7 @@ function Search-CustomFoldersForExecutables {
                 # Create checkbox for selection
                 $checkbox = New-Object System.Windows.Controls.CheckBox
                 $checkbox.Content = $executable.Name
-                $checkbox.Foreground = "White"
+                $checkbox.Foreground = "#F5F3FF"
                 $checkbox.FontWeight = "SemiBold"
                 $checkbox.Tag = $executable.Path  # Store full path for optimization
                 $stackPanel.Children.Add($checkbox)
@@ -8272,14 +8277,14 @@ function Search-CustomFoldersForExecutables {
                 # Add details
                 $detailsText = New-Object System.Windows.Controls.TextBlock
                 $detailsText.Text = "🔍 $($executable.Details)"
-                $detailsText.Foreground = "#B8B8B8"
+                $detailsText.Foreground = "#A9A5D9"
                 $detailsText.FontSize = 10
                 $detailsText.Margin = "20,2,0,0"
                 $stackPanel.Children.Add($detailsText)
 
                 $fileDetailsText = New-Object System.Windows.Controls.TextBlock
                 $fileDetailsText.Text = "💾 File: $($executable.ExecutableName) | Size: $($executable.Size) MB | Modified: $($executable.LastModified.ToString('yyyy-MM-dd'))"
-                $fileDetailsText.Foreground = "#777EA6888"
+                $fileDetailsText.Foreground = "#7D7EB0"
                 $fileDetailsText.FontSize = 9
                 $fileDetailsText.Margin = "20,1,0,0"
                 $stackPanel.Children.Add($fileDetailsText)
@@ -10118,7 +10123,7 @@ if ($btnAutoDetect) {
             if ($lblDashActiveGames) {
                 $lblDashActiveGames.Dispatcher.Invoke([Action]{
                     $lblDashActiveGames.Text = "$($detectedGames.Count) running"
-                    $lblDashActiveGames.Foreground = "#5D5FEF"
+                    $lblDashActiveGames.Foreground = "#8F6FFF"
                 })
             }
 
@@ -11381,7 +11386,7 @@ function Start-CustomFolderOnlySearch {
         # Add loading message
         $loadingText = New-Object System.Windows.Controls.TextBlock
         $loadingText.Text = "🔍 Searching '$FolderPath' for all executables (.exe)..."
-        $loadingText.Foreground = "#A08BFF"
+        $loadingText.Foreground = "#8F6FFF"
         $loadingText.FontStyle = "Italic"
         $loadingText.HorizontalAlignment = "Center"
         $loadingText.Margin = "0,20"
@@ -11426,7 +11431,7 @@ function Start-CustomFolderOnlySearch {
             # Add header
             $headerText = New-Object System.Windows.Controls.TextBlock
             $headerText.Text = "Found $($foundExecutables.Count) Executables in '$([System.IO.Path]::GetFileName($FolderPath))'"
-            $headerText.Foreground = "#5D5FEF"
+            $headerText.Foreground = "#8F6FFF"
             $headerText.FontWeight = "Bold"
             $headerText.FontSize = 14
             $headerText.Margin = "0,0,0,10"
@@ -11435,9 +11440,9 @@ function Start-CustomFolderOnlySearch {
             # Add each executable with optimization option
             foreach ($executable in $foundExecutables) {
                 $gamePanel = New-Object System.Windows.Controls.Border
-                $gamePanel.Background = "#1A1F39"
+                $gamePanel.Background = "#14132B"
                 try {
-                    $gamePanel.BorderBrush = "#2F3A73"
+                    $gamePanel.BorderBrush = "#2F285A"
                     $gamePanel.BorderThickness = "1"
                 } catch {
                     Write-Verbose "BorderBrush assignment skipped for .NET Framework 4.8 compatibility"
@@ -11455,14 +11460,14 @@ function Start-CustomFolderOnlySearch {
 
                 $gameName = New-Object System.Windows.Controls.TextBlock
                 $gameName.Text = $executable.Name
-                $gameName.Foreground = "White"
+                $gameName.Foreground = "#F5F3FF"
                 $gameName.FontWeight = "Bold"
                 $gameName.FontSize = 14
                 $gameInfo.Children.Add($gameName)
 
                 $gameDetails = New-Object System.Windows.Controls.TextBlock
                 $gameDetails.Text = "📁 $($executable.Path)`n📊 Size: $($executable.Size) MB | 📅 Modified: $($executable.LastModified)"
-                $gameDetails.Foreground = "#A6AACF"
+                $gameDetails.Foreground = "#A9A5D9"
                 $gameDetails.FontSize = 10
                 $gameDetails.TextWrapping = "Wrap"
                 $gameInfo.Children.Add($gameDetails)
@@ -11507,7 +11512,7 @@ function Start-CustomFolderOnlySearch {
         } else {
             $noGamesText = New-Object System.Windows.Controls.TextBlock
             $noGamesText.Text = "No executable files (.exe) found in the selected folder.`n`nTip: Make sure the folder contains game installations or executable files."
-            $noGamesText.Foreground = "#777EA6"
+            $noGamesText.Foreground = "#7D7EB0"
             $noGamesText.FontStyle = "Italic"
             $noGamesText.HorizontalAlignment = "Center"
             $noGamesText.TextAlignment = "Center"
@@ -11619,7 +11624,7 @@ function Start-AllCustomFoldersSearch {
         # Add loading message
         $loadingText = New-Object System.Windows.Controls.TextBlock
         $loadingText.Text = "🔍 Searching all custom folders for executables..."
-        $loadingText.Foreground = "#A08BFF"
+        $loadingText.Foreground = "#8F6FFF"
         $loadingText.FontStyle = "Italic"
         $loadingText.HorizontalAlignment = "Center"
         $loadingText.Margin = "0,20"
@@ -11656,7 +11661,7 @@ function Start-AllCustomFoldersSearch {
         if ($allExecutables.Count -gt 0) {
             $headerText = New-Object System.Windows.Controls.TextBlock
             $headerText.Text = "Found $($allExecutables.Count) Executables in Custom Folders"
-            $headerText.Foreground = "#5D5FEF"
+            $headerText.Foreground = "#8F6FFF"
             $headerText.FontWeight = "Bold"
             $headerText.FontSize = 14
             $headerText.Margin = "0,0,0,10"
@@ -11664,9 +11669,9 @@ function Start-AllCustomFoldersSearch {
 
             foreach ($exe in $allExecutables) {
                 $gamePanel = New-Object System.Windows.Controls.Border
-                $gamePanel.Background = "#1A1F39"
+                $gamePanel.Background = "#14132B"
                 try {
-                    $gamePanel.BorderBrush = "#2F3A73"
+                    $gamePanel.BorderBrush = "#2F285A"
                     $gamePanel.BorderThickness = "1"
                 } catch {
                     Write-Verbose "BorderBrush assignment skipped for .NET Framework 4.8 compatibility"
@@ -11683,14 +11688,14 @@ function Start-AllCustomFoldersSearch {
 
                 $gameName = New-Object System.Windows.Controls.TextBlock
                 $gameName.Text = $exe.Name
-                $gameName.Foreground = "White"
+                $gameName.Foreground = "#F5F3FF"
                 $gameName.FontWeight = "Bold"
                 $gameName.FontSize = 14
                 $gameInfo.Children.Add($gameName)
 
                 $gameDetails = New-Object System.Windows.Controls.TextBlock
                 $gameDetails.Text = "📁 From: $($exe.Folder) | 📊 $($exe.Size) MB | 📅 $($exe.LastModified)"
-                $gameDetails.Foreground = "#A6AACF"
+                $gameDetails.Foreground = "#A9A5D9"
                 $gameDetails.FontSize = 10
                 $gameInfo.Children.Add($gameDetails)
 
@@ -11725,7 +11730,7 @@ function Start-AllCustomFoldersSearch {
         } else {
             $noGamesText = New-Object System.Windows.Controls.TextBlock
             $noGamesText.Text = "No executable files found in custom folders."
-            $noGamesText.Foreground = "#777EA6"
+            $noGamesText.Foreground = "#7D7EB0"
             $noGamesText.FontStyle = "Italic"
             $noGamesText.HorizontalAlignment = "Center"
             $noGamesText.Margin = "0,20"
@@ -12534,7 +12539,7 @@ function Initialize-Application {
             # Administrator mode - full access
             if ($lblAdminStatus) {
                 $lblAdminStatus.Text = "Administrator Mode"
-                $lblAdminStatus.Foreground = "#5D5FEF"
+                $lblAdminStatus.Foreground = "#8F6FFF"
             }
             if ($lblAdminDetails) {
                 $lblAdminDetails.Text = "All optimizations available"
@@ -12553,7 +12558,7 @@ function Initialize-Application {
             # Limited mode - some restrictions
             if ($lblAdminStatus) {
                 $lblAdminStatus.Text = "Limited Mode"
-                $lblAdminStatus.Foreground = "#A08BFF"
+                $lblAdminStatus.Foreground = "#8F6FFF"
             }
             if ($lblAdminDetails) {
                 $lblAdminDetails.Text = "Some optimizations require administrator privileges"


### PR DESCRIPTION
## Summary
- refresh the default Nebula theme palette to a purple and midnight-toned scheme and wire the theme mapper to surface the new accent resources
- rework the main WPF resource dictionary and navigation styles so buttons, combo boxes, and cards adopt the new vortex-inspired colors
- retheme auxiliary dialogs (system health, log search, installed games) and tune dynamic status colours to keep runtime UI feedback aligned with the purple accent

## Testing
- `pwsh -NoLogo -NoProfile -File V3-testing.ps1 -SyntaxCheckOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d09628c904832085ed59a263436345