### PR TITLE
Restore admin privilege detection error handling

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -646,18 +646,21 @@ function Test-AdminPrivileges {
         return $false
     }
 
+    try {
         $id = [Security.Principal.WindowsIdentity]::GetCurrent()
         if (-not $id) {
             return $false
-
         }
 
         $principal = New-Object Security.Principal.WindowsPrincipal($id)
         return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    catch {
         $warningMessage = 'Admin privilege detection unavailable: {0}' -f $_.Exception.Message
         Log $warningMessage 'Warning'
         return $false
     }
+}
 
 function Get-SafeConfigPath {
     param([string]$Filename)


### PR DESCRIPTION
## Summary
- restore the try/catch wrapper around Windows identity detection in Test-AdminPrivileges
- route the warning log through the catch block and ensure the function closes all scopes properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d638aca98c83208275ce75a17febed