### PR TITLE
Fix missing closing brace in Run-QuickOptimizations

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -13079,6 +13079,7 @@ function Run-QuickOptimizations {
         reg add 'HKCU\System\GameConfigStore' /v GameDVR_FSEBehaviorMode /t REG_DWORD /d 2 /f | Out-Null
         Log 'Quick optimizations applied successfully.' 'Success'
         Log "Quick optimizations failed: $($_.Exception.Message)" 'Error'
+}
 
 $btnQuickOptimize.Add_Click({
     Run-QuickOptimizations


### PR DESCRIPTION
## Summary
- add the missing closing brace for the `Run-QuickOptimizations` function so the script compiles correctly
- confirm the adjacent button click handlers already close their script blocks properly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d664138960832084e75a74e6efb47c