### PR TITLE
Fix System Health dialog handlers

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -3646,21 +3646,29 @@ function Show-SystemHealthDialog {
 
         $btnOptimizeNow.Add_Click({
             if ($btnApply) {
-                Log "Quick optimization triggered from System Health dialog" 'Info'
-                $healthWindow.Close()
+                try {
+                    Log "Quick optimization triggered from System Health dialog" 'Info'
+                    $healthWindow.Close()
 
                     $btnApply.RaiseEvent([System.Windows.RoutedEventArgs]::new([System.Windows.Controls.Primitives.ButtonBase]::ClickEvent))
+                } catch {
                     Log "Error triggering optimization from health dialog: $($_.Exception.Message)" 'Error'
+                    [System.Windows.MessageBox]::Show("Could not start quick optimization: $($_.Exception.Message)", "Optimization Error", 'OK', 'Error')
                 }
             } else {
                 [System.Windows.MessageBox]::Show("Quick optimization is not available. Please use the main optimization features.", "Optimization", 'OK', 'Information')
+            }
+        })
 
         $btnOpenTaskManager.Add_Click({
+            try {
                 Start-Process "taskmgr.exe" -ErrorAction Stop
                 Log "Task Manager opened from System Health dialog" 'Info'
+            } catch {
                 Log "Error opening Task Manager: $($_.Exception.Message)" 'Warning'
                 [System.Windows.MessageBox]::Show("Could not open Task Manager: $($_.Exception.Message)", "Task Manager Error", 'OK', 'Warning')
             }
+        })
 
         $btnCloseHealth.Add_Click({
             Log "System Health dialog closed by user" 'Info'


### PR DESCRIPTION
## Summary
- repair the System Health dialog button handlers so their scriptblocks close correctly
- wrap the quick optimize and task manager actions in try/catch blocks that log and surface any errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6970b45c88320a0777b979d64383c