### PR TITLE
Handle WPF assembly load failures gracefully

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -58,10 +58,15 @@ if (-not $script:IsWindowsPlatform) {
         'System.Windows.Forms'
         'Microsoft.VisualBasic'
     )
-    Add-Type -AssemblyName $assemblies -ErrorAction Stop
-    $warning = "Warning: WPF assemblies not available. This script requires Windows with .NET Framework."
-    Write-Host $warning -ForegroundColor Yellow
-    return
+    try {
+        Add-Type -AssemblyName $assemblies -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Error loading WPF assemblies: $($_.Exception.Message)" -ForegroundColor Red
+        $warning = "Warning: WPF assemblies not available. This script requires Windows with .NET Framework."
+        Write-Host $warning -ForegroundColor Yellow
+        return
+    }
 
 $BrushConverter = New-Object System.Windows.Media.BrushConverter
 


### PR DESCRIPTION
## Summary
- wrap the WPF assembly load in a try/catch block to prevent unhandled errors
- only show the WPF availability warning when Add-Type fails
- log the caught exception to aid troubleshooting before returning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6a3922e8c8320ac7d1cb2dec61e93