### PR TITLE
Fix default handling in Get-SystemPerformanceMetrics

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -319,18 +319,21 @@ function Get-SystemPerformanceMetrics {
 
         }
 
-        # Get CPU usage
-            $cpu = Get-WmiObject -Class Win32_Processor | Measure-Object -Property LoadPercentage -Average
-            $metrics.CPU = [math]::Round($cpu.Average, 1)
-            $metrics.CPU = 0
-        }
+        try {
+            # Get CPU usage
+                $cpu = Get-WmiObject -Class Win32_Processor | Measure-Object -Property LoadPercentage -Average
+                $metrics.CPU = [math]::Round($cpu.Average, 1)
 
-        # Get Memory usage
-            $totalMemory = (Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory
-            $availableMemory = (Get-WmiObject -Class Win32_OperatingSystem).AvailablePhysicalMemory
-            $usedMemory = $totalMemory - $availableMemory
-            $metrics.Memory = [math]::Round(($usedMemory / $totalMemory) * 100, 1)
+            # Get Memory usage
+                $totalMemory = (Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory
+                $availableMemory = (Get-WmiObject -Class Win32_OperatingSystem).AvailablePhysicalMemory
+                $usedMemory = $totalMemory - $availableMemory
+                $metrics.Memory = [math]::Round(($usedMemory / $totalMemory) * 100, 1)
+        }
+        catch {
+            $metrics.CPU = 0
             $metrics.Memory = 0
+        }
 
         if ($Detailed) {
             # Add more detailed metrics if needed
@@ -339,13 +342,7 @@ function Get-SystemPerformanceMetrics {
         }
 
         return $metrics
-        # Return default metrics on error
-        return @{
-            CPU = 0
-            Memory = 0
-            Disk = 0
-            Network = 0
-        }
+}
 
 function Ensure-NavigationVisibility {
     param([System.Windows.Controls.Panel]$NavigationPanel)


### PR DESCRIPTION
## Summary
- wrap the WMI metrics collection in a try/catch block so defaults are only applied on failure
- remove unconditional CPU and memory resets to preserve collected values
- ensure the function returns the populated metrics without unreachable fallback code

## Testing
- not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a5f75cd88320953ed066d7d5d4fc