### PR TITLE
Fix braces in Update-SystemHealthSummary

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -3359,6 +3359,9 @@ function Update-SystemHealthSummary {
                 default { $foreground = '#A6AACF' }
             }
 
+        }
+        }
+
         if ($lblDashSystemHealth) {
             $lblDashSystemHealth.Dispatcher.Invoke([Action]{
                 $lblDashSystemHealth.Text = $text
@@ -3366,6 +3369,8 @@ function Update-SystemHealthSummary {
             })
         }
         Log "Error updating dashboard health summary: $($_.Exception.Message)" 'Warning'
+
+}
 
 function Update-SystemHealthDisplay {
     param([switch]$RunCheck)


### PR DESCRIPTION
## Summary
- add missing closing braces to complete the if/elseif logic in Update-SystemHealthSummary
- close the function after the dashboard dispatcher update block to avoid scope issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bd096ab883209ba4cc9a7abfe87d