### PR TITLE
Fix script root fallback logic

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -386,7 +386,9 @@ if ($PSScriptRoot) {
     $ScriptRoot = $PSScriptRoot
 } elseif ($MyInvocation -and $MyInvocation.MyCommand -and $MyInvocation.MyCommand.Path) {
     $ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+} else {
     $ScriptRoot = (Get-Location).Path
+}
 
 # Function moved to after helper functions to fix call order
 


### PR DESCRIPTION
## Summary
- add a missing closing brace to the ScriptRoot resolution block
- ensure the ScriptRoot fallback uses Get-Location in an else branch

## Testing
- attempted to parse V4-TESTING.ps1 with PowerShell but pwsh is not available in the environment


------
https://chatgpt.com/codex/tasks/task_e_68d7b80780c08320870d604b26f8456f