### PR TITLE
Ensure Windows warning uses correct foreground color

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -42,7 +42,7 @@ $script:IsWindowsPlatform = $false
     $script:IsWindowsPlatform = ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT)
 
 if (-not $script:IsWindowsPlatform) {
-    Write-Host 'KOALA Gaming Optimizer requires Windows because it depends on WPF and Windows-specific APIs.' -ForegroundColor Yellow
+    Write-Host "KOALA Gaming Optimizer requires Windows because it depends on WPF and Windows-specific APIs." -ForegroundColor Yellow
     return
 }
 


### PR DESCRIPTION
## Summary
- ensure the Windows-specific warning message sets `-ForegroundColor Yellow` on a single line to prevent stray token execution

## Testing
- not run (PowerShell is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d7cbd4ab4883209bcb31de6d0d77e8