### PR TITLE
Fix Show-ElevationMessage switch structure

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -5071,15 +5071,17 @@ function Show-ElevationMessage {
 
     switch ($result) {
         'Yes' {
+            try {
                 $scriptPath = $PSCommandPath
                 if (-not $scriptPath) {
                     $scriptPath = Join-Path $ScriptRoot "koalafixed.ps1"
-
                 }
 
                 Start-Process -FilePath "powershell.exe" -ArgumentList "-ExecutionPolicy Bypass -File `"$scriptPath`"" -Verb RunAs -ErrorAction Stop
                 $form.Close()
                 return $true
+            }
+            catch {
                 Log "Failed to elevate privileges: $($_.Exception.Message)" 'Error'
                 return $false
             }
@@ -5094,6 +5096,7 @@ function Show-ElevationMessage {
             return $false
         }
     }
+}
 
 function Get-SystemInfo {
         $info = @{


### PR DESCRIPTION
## Summary
- keep the No and Cancel branches inside the Show-ElevationMessage switch by moving the closing brace
- wrap the elevation relaunch logic in a try/catch so failures log an error without exiting early

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7d76d83f08320bed61691db0878d1