### PR TITLE
Fix game search error handling and handler scope

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -8169,6 +8169,7 @@ function Show-InstalledGames {
             foreach ($path in $searchPaths) {
                 if (Test-Path $path) {
                     Log "Searching in: $path" 'Info'
+                    try {
                         # Search for known game executables with verification
                         foreach ($exe in $gameExecutables.Keys) {
                             $foundFiles = Get-ChildItem -Path $path -Recurse -Name $exe -ErrorAction SilentlyContinue
@@ -8304,6 +8305,7 @@ function Show-InstalledGames {
             }
 
             return $games
+        }
 
         # Initial search
         $foundGames = Search-InstalledGames
@@ -8338,6 +8340,7 @@ function Show-InstalledGames {
                 $lstInstalledGames.ItemsSource = $noGamesFound
                 Log "Refresh complete: No games found" 'Warning'
             }
+        })
 
         $btnCloseGames.Add_Click({
             Log "Installed Games window closed by user" 'Info'


### PR DESCRIPTION
## Summary
- wrap the installed game scanning loops in a try/catch that matches the existing error handler
- close the Search-InstalledGames function immediately after returning the results
- ensure the refresh button handler is closed before declaring the other window event handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8e07b0c7083208491746813145dd6