### PR TITLE
Close Apply-FPSOptimizations scope

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -9182,6 +9182,12 @@ function Apply-FPSOptimizations {
                 Log "CPU optimization applied" 'Success'
             }
 
+        }
+
+    }
+
+}
+
 # ---------- DirectX 11 Optimization Functions ----------
 function Apply-DX11Optimizations {
     param([string[]]$OptimizationList)


### PR DESCRIPTION
## Summary
- add missing closing braces for Apply-FPSOptimizations, its loop, and switch statement
- ensure the DirectX 11 optimization section comment sits outside the FPS optimization function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8eba1958883208a5317a32d35299a