### PR TITLE
Wrap installed games dialog in try/catch

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -8321,6 +8321,7 @@ function Show-InstalledGames {
             })
             $lstInstalledGames.ItemsSource = $noGamesFound
             Log "No games found in common directories" 'Warning'
+        }
 
         # Event handlers
         $btnRefreshGames.Add_Click({
@@ -8348,10 +8349,14 @@ function Show-InstalledGames {
         })
 
         # Show the window
-        $gamesWindow.ShowDialog() | Out-Null
-
-        Log "Error showing installed games: $($_.Exception.Message)" 'Error'
-        [System.Windows.MessageBox]::Show("Error displaying installed games window: $($_.Exception.Message)", "Installed Games Error", 'OK', 'Error')
+        try {
+            $gamesWindow.ShowDialog() | Out-Null
+        }
+        catch {
+            Log "Error showing installed games: $($_.Exception.Message)" 'Error'
+            [System.Windows.MessageBox]::Show("Error displaying installed games window: $($_.Exception.Message)", "Installed Games Error", 'OK', 'Error')
+        }
+}
 
 # Helper functions for synchronizing game list UI across multiple panels
 function Set-OptimizeButtonsEnabled {


### PR DESCRIPTION
## Summary
- close the installed games discovery workflow by wrapping the dialog display in a try/catch
- ensure the Show-InstalledGames function ends before other helper functions so they remain top-level

## Testing
- Not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8f76d21908320a7b800a0e5f1cb46