### PR TITLE
Fix theme normalization braces and brush handling

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -1062,7 +1062,10 @@ function Normalize-ThemeColorTable {
 
         if ($value -is [string]) {
             $stringBrush = $null
+            try {
                 $stringBrush = New-SolidColorBrushSafe $value
+            }
+            catch {
                 $stringBrush = $null
             }
 
@@ -1076,10 +1079,12 @@ function Normalize-ThemeColorTable {
 
         if ($value -is [bool]) { continue }
         if ($value -is [System.Windows.Media.Brush]) {
+            try {
                 if ($value -is [System.Windows.Freezable] -and -not $value.IsFrozen) {
                     $value.Freeze()
-
                 }
+            }
+            catch {
                 Write-Verbose "Normalize-ThemeColorTable: Failed to freeze brush for key '$key'"
             }
             continue
@@ -1090,8 +1095,10 @@ function Normalize-ThemeColorTable {
         if (-not [string]::IsNullOrWhiteSpace($resolved)) {
             $Theme[$key] = $resolved
         }
+    }
 
     return $Theme
+}
 
 # Creates a cloneable brush instance from a variety of incoming values.
 function Resolve-BrushInstance {
@@ -1108,15 +1115,17 @@ function Resolve-BrushInstance {
     }
 
     if ($current -is [System.Windows.Media.Brush]) {
+        try {
             $clone = if ($current -is [System.Windows.Freezable]) { $current.Clone() } else { $current }
             if ($clone -is [System.Windows.Freezable] -and -not $clone.IsFrozen) {
                 try { $clone.Freeze() } catch { }
-
             }
             return $clone
-        } catch {
+        }
+        catch {
             return $current
         }
+    }
 
     return $null
 


### PR DESCRIPTION
## Summary
- ensure `Normalize-ThemeColorTable` closes its loop and function blocks correctly
- harden brush freezing in the theme normalizer with guarded try/catch logic
- wrap `Resolve-BrushInstance` cloning logic in a balanced try/catch block

## Testing
- `powershell -NoProfile -Command { . .\V4-TESTING.ps1 }` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d917c131d08320b1815fc2381589aa