### PR TITLE
Wrap theme selection handler in try/catch

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -10769,7 +10769,8 @@ $btnBasicGaming.Add_Click({
 # Options panel event handlers - selection changes only update preview, no instant application
 if ($cmbOptionsTheme) {
     $cmbOptionsTheme.Add_SelectionChanged({
-        if ($script:ThemeSelectionSyncInProgress) { return }
+        try {
+            if ($script:ThemeSelectionSyncInProgress) { return }
 
             $script:ThemeSelectionSyncInProgress = $true
 
@@ -10796,9 +10797,13 @@ if ($cmbOptionsTheme) {
 
                 Log "Theme selection changed to '$themeName' - preview updated (Apply button required for theme change)" 'Info'
             }
+        } catch {
             Log "Error updating theme preview: $($_.Exception.Message)" 'Error'
         } finally {
             $script:ThemeSelectionSyncInProgress = $false
+        }
+    })
+}
 
 # Apply button - primary method for theme application (themes only apply when clicked)
 # Theme Apply Button Event Handler


### PR DESCRIPTION
## Summary
- wrap the theme selection change handler in a try/finally so the sync flag is always reset
- add a catch block that logs preview update errors and close the handler and surrounding block properly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9785717f88320b6efad92c21ba7a0