### PR TITLE
Add guards around SolidColorBrush coercion

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -1163,18 +1163,24 @@ function New-SolidColorBrushSafe {
     if ($existingBrush -is [System.Windows.Media.Brush]) {
         try {
             $colorText = $existingBrush.ToString()
-            if (-not [string]::IsNullOrWhiteSpace($colorText)) {
+        }
+        catch {
+            Write-Verbose "Failed to read brush value for '$existingBrush': $($_.Exception.Message)"
+            $colorText = $null
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($colorText)) {
+            try {
                 $colorCandidate = [System.Windows.Media.ColorConverter]::ConvertFromString($colorText)
                 if ($colorCandidate -is [System.Windows.Media.Color]) {
                     $fromBrush = New-Object System.Windows.Media.SolidColorBrush $colorCandidate
                     $fromBrush.Freeze()
                     return $fromBrush
-
                 }
             }
-        }
-        catch {
-            Write-Verbose "Failed to coerce brush value '$existingBrush' to SolidColorBrush: $($_.Exception.Message)"
+            catch {
+                Write-Verbose "Failed to coerce brush value '$existingBrush' to SolidColorBrush: $($_.Exception.Message)"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- wrap the SolidColorBrush coercion logic in `New-SolidColorBrushSafe` with dedicated try/catch blocks so failures are logged and handled gracefully
- ensure the function terminates directly after the final `return $null` to keep the block structure intact

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da3f04941c83209be6f9d68c28ab84