### PR TITLE
Fix shared brush converter and shape fill error handling

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -1226,12 +1226,11 @@ function New-SolidColorBrushSafe {
 
 function Get-SharedBrushConverter {
     if (-not $script:SharedBrushConverter -or $script:SharedBrushConverter.GetType().FullName -ne 'System.Windows.Media.BrushConverter') {
-            $script:SharedBrushConverter = [System.Windows.Media.BrushConverter]::new()
-            $script:SharedBrushConverter = $null
-        }
+        $script:SharedBrushConverter = [System.Windows.Media.BrushConverter]::new()
     }
 
     return $script:SharedBrushConverter
+}
 
 function Set-ShapeFillSafe {
     param(
@@ -1241,9 +1240,13 @@ function Set-ShapeFillSafe {
 
     if (-not $Shape) { return }
 
+    try {
         Set-BrushPropertySafe -Target $Shape -Property 'Fill' -Value $Value -AllowTransparentFallback
+    }
+    catch {
         Write-Verbose "Set-ShapeFillSafe failed: $($_.Exception.Message)"
     }
+}
 
 # Centralized helper to assign Brush-like theme values to WPF dependency properties.
 function Set-BrushPropertySafe {


### PR DESCRIPTION
## Summary
- ensure Get-SharedBrushConverter only initializes the shared converter when needed and return braces are balanced
- wrap Set-ShapeFillSafe in a try/catch so brush assignment failures are logged without breaking parsing

## Testing
- powershell -NoLogo -Command "[System.Management.Automation.Language.Parser]::ParseFile('V4-TESTING.ps1',[ref]$null,[ref]$null)" *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da405a05e0832081cfe7de2e366d49