### PR TITLE
Fix braces in performance monitoring functions

### DIFF
--- a/V4-TESTING.ps1
+++ b/V4-TESTING.ps1
@@ -4305,6 +4305,7 @@ function Update-DashboardMetrics {
     Safely updates dashboard UI elements with current system performance data
     #>
 
+    try {
         $metrics = Get-SystemPerformanceMetrics
 
         # Update CPU Usage
@@ -4314,14 +4315,14 @@ function Update-DashboardMetrics {
 
                 # Color coding based on CpuUsage and MemoryUsagePercent for dynamic metrics display
                 if ($metrics.CpuUsage -ge 80) {
-                    Set-BrushPropertySafe -Target $lblDashCpuUsage -Property 'Foreground' -Value '#FF4444'  # Red for high
-
+                    Set-BrushPropertySafe -Target $lblDashCpuUsage -Property 'Foreground' -Value '#FF4444'  # Red for high load
                 } elseif ($metrics.CpuUsage -ge 60) {
                     Set-BrushPropertySafe -Target $lblDashCpuUsage -Property 'Foreground' -Value '#A78BFA'  # Purple for medium load
                 } else {
                     Set-BrushPropertySafe -Target $lblDashCpuUsage -Property 'Foreground' -Value '#8F6FFF'  # Accent for low load
                 }
             })
+        }
 
         # Update Memory Usage
         if ($lblDashMemoryUsage) {
@@ -4336,6 +4337,8 @@ function Update-DashboardMetrics {
                 } else {
                     Set-BrushPropertySafe -Target $lblDashMemoryUsage -Property 'Foreground' -Value '#8F6FFF'  # Accent for normal
                 }
+            })
+        }
 
         if ($lblHeroProfiles) {
             $lblHeroProfiles.Dispatcher.Invoke([Action]{
@@ -4367,6 +4370,7 @@ function Update-DashboardMetrics {
                     Set-BrushPropertySafe -Target $lblDashActiveGames -Property 'Foreground' -Value '#A6AACF'  # Default color
                 }
             })
+        }
 
         # Update Last Optimization
         if ($lblDashLastOptimization) {
@@ -4393,12 +4397,16 @@ function Update-DashboardMetrics {
                     $lblHeaderSystemStatus.Text = 'Stable'
                     Set-BrushPropertySafe -Target $lblHeaderSystemStatus -Property 'Foreground' -Value [System.Windows.Media.Brushes]::LightGreen
                 }
+            })
+        }
 
         # Refresh System Health summary without running a full check
         Update-SystemHealthSummary
-
+    } catch {
         # Silent fail to prevent UI disruption
         Write-Verbose "Dashboard metrics update failed: $($_.Exception.Message)"
+    }
+}
 
 function Start-PerformanceMonitoring {
     <#
@@ -4408,9 +4416,9 @@ function Start-PerformanceMonitoring {
     Initializes a dispatcher timer for regular dashboard updates
     #>
 
+    try {
         if ($global:PerformanceTimer) {
             $global:PerformanceTimer.Stop()
-
         }
 
         # Create dispatcher timer for UI updates
@@ -4429,9 +4437,10 @@ function Start-PerformanceMonitoring {
         Update-DashboardMetrics
 
         Log "Real-time performance monitoring started (3s intervals)" 'Success'
-
+    } catch {
         Log "Error starting performance monitoring: $($_.Exception.Message)" 'Error'
     }
+}
 
 function Stop-PerformanceMonitoring {
     <#
@@ -4439,14 +4448,16 @@ function Stop-PerformanceMonitoring {
     Stops the performance monitoring timer
     #>
 
+    try {
         if ($global:PerformanceTimer) {
             $global:PerformanceTimer.Stop()
             $global:PerformanceTimer = $null
             Log "Performance monitoring stopped" 'Info'
-
         }
+    } catch {
         Write-Verbose "Error stopping performance monitoring: $($_.Exception.Message)"
     }
+}
 
 # ---------- Enhanced Game Detection and Auto-Optimization ----------
 $global:ActiveGameProcesses = @()


### PR DESCRIPTION
## Summary
- wrap `Update-DashboardMetrics` logic in a try/catch and close all dispatcher update branches
- ensure the performance monitoring start/stop helpers have matching try/catch handling and restore the related global initializers

## Testing
- PowerShell script parse check *(fails: PowerShell executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db031e42588320b6cf2b888cd8b5c1