### PR TITLE
Replace header gradient with solid accent background

### DIFF
--- a/KOALAOptimizer.Testing/MainWindow.xaml
+++ b/KOALAOptimizer.Testing/MainWindow.xaml
@@ -110,14 +110,8 @@
             <RowDefinition Height="60"/>
         </Grid.RowDefinitions>
 
-        <!-- Header with gradient -->
-        <Border Grid.Row="0" Padding="15">
-            <Border.Background>
-                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                    <GradientStop Color="#6d28d9" Offset="0"/>
-                    <GradientStop Color="#8b5cf6" Offset="1"/>
-                </LinearGradientBrush>
-            </Border.Background>
+        <!-- Header with accent background -->
+        <Border Grid.Row="0" Padding="15" Background="{StaticResource AccentPurple}">
             <StackPanel>
                 <TextBlock Text="🐨 KOALA Gaming Optimizer v3.0" FontSize="24" FontWeight="Bold" Foreground="White"/>
                 <TextBlock Text="Advanced Windows gaming optimization with comprehensive FPS-boosting features" FontSize="12" Foreground="#e9d5ff"/>


### PR DESCRIPTION
## Summary
- replace the main window header gradient with the existing AccentPurple solid brush
- update the header comment to reflect the solid accent background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2366c8408320a764586a68d52007