### PR TITLE
Guard WPF assembly loading failures

### DIFF
--- a/V3-testing.ps1
+++ b/V3-testing.ps1
@@ -58,10 +58,14 @@ if (-not $script:IsWindowsPlatform) {
         'System.Windows.Forms'
         'Microsoft.VisualBasic'
     )
-    Add-Type -AssemblyName $assemblies -ErrorAction Stop
-    $warning = "Warning: WPF assemblies not available. This script requires Windows with .NET Framework."
-    Write-Host $warning -ForegroundColor Yellow
-    return
+    try {
+        Add-Type -AssemblyName $assemblies -ErrorAction Stop
+    }
+    catch {
+        $warning = "Warning: WPF assemblies not available. This script requires Windows with .NET Framework."
+        Write-Host $warning -ForegroundColor Yellow
+        return
+    }
 
 $BrushConverter = New-Object System.Windows.Media.BrushConverter
 


### PR DESCRIPTION
## Summary
- wrap WPF assembly loading in a try/catch so the warning and early return only trigger when loading fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd9290acf48320bb7f1e389e01924b